### PR TITLE
plymouthd.defaults is now in branding package

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -366,10 +366,10 @@ pam:
 if exists(plymouth)
   plymouth:
     /
-    R s/^Theme=.*/Theme=tribar/ /usr/share/plymouth/plymouthd.defaults
   plymouth-scripts: nodeps
   plymouth-plugin-script:
   plymouth-branding-<plymouth_theme>: nodeps
+      R s/^Theme=.*/Theme=tribar/ /usr/share/plymouth/plymouthd.defaults
   ?plymouth-theme-tribar:
 endif
 


### PR DESCRIPTION
with jsc#SLE-11637, /usr/share/plymouth/plymouthd.defaults has been moved to branding package.